### PR TITLE
Add XXL benchmarking

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -28,7 +28,7 @@ jobs:
       
       - name: Generate benchmarks
         run: |
-          cargo bench
+          cargo bench --all-features
 
       - name: Push to repo
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,3 +52,4 @@ required-features = ["datagen", "serde"]
 [[bench]]
 name = "criterion"
 harness = false
+required-features = ["datagen", "serde"]

--- a/src/constraint/unweighted.rs
+++ b/src/constraint/unweighted.rs
@@ -13,7 +13,9 @@ use super::{Address, Constraint, ConstraintVec, ElementaryConstraint, NodeRange,
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum UnweightedAdjConstraint {
+    /// The port is not linked.
     Dangling,
+    /// The port is linked to a node satisfying the constraints.
     Link(ConstraintVec<()>),
 }
 

--- a/src/constraint/weighted.rs
+++ b/src/constraint/weighted.rs
@@ -18,7 +18,9 @@ use super::{Address, ConstraintVec, NodeRange, PortAddress};
 /// Furthermore, a constraint can include a condition on the target node weight
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum WeightedAdjConstraint<N> {
+    /// The port is not linked.
     Dangling,
+    /// The port is linked to a node satisfying the constraints.
     Link(ConstraintVec<N>),
 }
 impl<N: Clone + Eq> WeightedAdjConstraint<N> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,12 @@
 #![warn(missing_docs)]
 #![doc = include_str!("../README.md")]
 
-mod constraint;
+pub mod constraint;
 pub mod graph_tries;
 pub mod matcher;
 pub mod pattern;
 pub mod utils;
 
-#[doc(inline)]
 pub use constraint::{Constraint, Skeleton};
 
 pub use matcher::{


### PR DESCRIPTION
- Allow serialization
- Pre-compile at CI datagen time
- REVERTME merge to bench
- revertme debug
- Allow multiple states in optim
- Revert "revertme debug"
- Increase cutoff
- Format and fix
- Rewrite split with multiple states
- Add test 48
- Fix test 48
- Format
- Add output at optim time
- Set cutoff to 100
- fn finalize perf
- Use binary serialization for tries
- Only precompute tries up to size 5k
- Add failed proptest
- Build matcher incrementally
- Pre-compile tries up to 9k
- Force use 0.2.3
- Incremental datagen (2)
- Revert "merge to bench"
- Remove datagen flag
- Only gen 9k circuits
- Make constraints pub + docs
- Add XXL benchmarking
