### PR TITLE
feat: N-arity constraints

### DIFF
--- a/src/new_api_v04/constraint.rs
+++ b/src/new_api_v04/constraint.rs
@@ -28,6 +28,30 @@ pub enum LiteralEvalError {
     UnboundVariable(String),
 }
 
+/// Errors that occur when constructing constraints.
+#[derive(Clone, Debug, Error)]
+pub enum InvalidConstraint {
+    /// Cannot assign a value if the RHS is not a variable
+    #[error("Cannot assign a value if the RHS is not a variable")]
+    AssignToValue,
+
+    /// Invalid predicate arity
+    #[error("Mismatching predicate arity and argument length")]
+    InvalidArity,
+
+    /// Constraints refers to an unbound variable
+    #[error("Constraint refered to unbound variable: {0}")]
+    UnboundVariable(String),
+}
+
+impl From<LiteralEvalError> for InvalidConstraint {
+    fn from(e: LiteralEvalError) -> Self {
+        match e {
+            LiteralEvalError::UnboundVariable(var) => InvalidConstraint::UnboundVariable(var),
+        }
+    }
+}
+
 impl<V: Debug, U> ConstraintLiteral<V, U> {
     /// Evaluate a literal to a value in U.
     ///
@@ -50,24 +74,21 @@ impl<V: Debug, U> ConstraintLiteral<V, U> {
 
 /// A constraint for pattern matching.
 ///
-/// Constraints must be carefully ordered when being satisfied as they make
+/// The following always holds:
+/// - The number of arguments `args.len()` matches the predicate arity N.
+/// - If the predicate is an `AssignPredicate`, the arity is >= 1 and the last
+///   argument must be a variable.
+///
+/// Note that constraints must be carefully ordered when being satisfied as they make
 /// assumptions on which variable bindings exist:
-///  - For AssignPredicates, the lhs, if it is a variable, must be already bound,
-///    and the rhs must always a variable.
-///  - For FilterPredicates, both lhs and rhs must be bound if they are variables.
+///  - For AssignPredicates, the first N-1 arguments must be constants or be
+///    variables bound by previous constraints.
+///  - For FilterPredicates, all arguments must be bound by previous constraints
+///    if they are variables.
 #[derive(Clone, Debug)]
 pub struct Constraint<V, U, AP, FP> {
-    lhs: ConstraintLiteral<V, U>,
     predicate: Predicate<AP, FP>,
-    rhs: ConstraintLiteral<V, U>,
-}
-
-/// Errors that occur when constructing constraints.
-#[derive(Clone, Debug, Error)]
-pub enum InvalidConstraint {
-    /// Cannot assign a value if the RHS is not a variable
-    #[error("Cannot assign a value if the RHS is not a variable")]
-    AssignToValue,
+    args: Vec<ConstraintLiteral<V, U>>,
 }
 
 impl<V, U, AP, FP> Constraint<V, U, AP, FP>
@@ -76,43 +97,74 @@ where
     AP: AssignPredicate<U = U>,
     FP: FilterPredicate<U = U>,
 {
-    /// Construct a constraint.
+    /// Construct a binary constraint.
     ///
     /// Returns an error if the constraint is malformed, i.e. if the predicate is
-    /// a Predicate::Assign and the object is not a variable.
-    pub fn try_from_triple(
+    /// a Predicate::Assign and the object is not a variable, or if the predicate
+    /// is not binary.
+    pub fn try_binary_from_triple(
         lhs: ConstraintLiteral<V, U>,
         predicate: Predicate<AP, FP>,
         rhs: ConstraintLiteral<V, U>,
     ) -> Result<Self, InvalidConstraint> {
+        if predicate.arity() != 2 {
+            return Err(InvalidConstraint::InvalidArity);
+        }
         if matches!(predicate, Predicate::Assign(_)) && matches!(rhs, ConstraintLiteral::Value(_)) {
             return Err(InvalidConstraint::AssignToValue);
         }
-        Ok(Self {
-            lhs,
-            predicate,
-            rhs,
-        })
+        Self::try_new(predicate, vec![lhs, rhs])
+    }
+
+    /// Construct a constraint.
+    ///
+    /// Returns an error if the number of arguments does not match the predicate
+    /// arity.
+    pub fn try_new(
+        predicate: Predicate<AP, FP>,
+        args: Vec<ConstraintLiteral<V, U>>,
+    ) -> Result<Self, InvalidConstraint> {
+        if args.len() != predicate.arity() {
+            Err(InvalidConstraint::InvalidArity)
+        } else if matches!(predicate, Predicate::Assign(_))
+            && matches!(args.last(), Some(ConstraintLiteral::Value(_)))
+        {
+            Err(InvalidConstraint::AssignToValue)
+        } else {
+            Ok(Self { args, predicate })
+        }
+    }
+
+    /// Return the arity of the constraint.
+    pub fn arity(&self) -> usize {
+        let arity = self.predicate.arity();
+        assert_eq!(self.args.len(), arity, "invalid constraint: arity mismatch");
+        arity
     }
 
     /// Return all variable assignments that would satisfy the constraint.
     ///
     /// This will panic if an `AssignPredicate` results in an invalid variable
     /// binding, or if the constraint is malformed.
-    pub fn satisfy<S, D>(&self, data: &D, scope: S) -> Result<Vec<S>, LiteralEvalError>
+    pub fn satisfy<S, D>(&self, data: &D, scope: S) -> Result<Vec<S>, InvalidConstraint>
     where
         S: Clone + VariableScope<V, U>,
         AP: AssignPredicate<D = D>,
         FP: FilterPredicate<D = D>,
     {
-        let subject = self.lhs.evaluate(&scope)?;
+        let args = |n_args| {
+            self.args[..n_args]
+                .iter()
+                .map(|arg| arg.evaluate(&scope))
+                .collect::<Result<Vec<_>, _>>()
+        };
         match &self.predicate {
             Predicate::Assign(ap) => {
-                let objects = ap.check_assign(data, subject);
-                let ConstraintLiteral::Variable(rhs) = &self.rhs else {
-                    panic!("Invalid constraint: rhs of AssignPredicate is a value");
+                let lhs = ap.check_assign(data, &args(self.arity() - 1)?);
+                let Some(ConstraintLiteral::Variable(rhs)) = &self.args.last() else {
+                    panic!("Invalid constraint: rhs of AssignPredicate is not a variable");
                 };
-                Ok(objects
+                Ok(lhs
                     .into_iter()
                     .map(|obj| {
                         let mut scope = scope.clone();
@@ -122,8 +174,8 @@ where
                     .collect())
             }
             Predicate::Filter(fp) => {
-                let object = self.rhs.evaluate(&scope)?;
-                if fp.check(data, subject, object) {
+                let args = args(self.arity())?;
+                if fp.check(data, &args) {
                     Ok([scope].to_vec())
                 } else {
                     Ok(Vec::new())

--- a/src/new_api_v04/constraint.rs
+++ b/src/new_api_v04/constraint.rs
@@ -137,8 +137,8 @@ where
 
     /// Return the arity of the constraint.
     pub fn arity(&self) -> usize {
-        let arity = self.predicate.arity();
-        assert_eq!(self.args.len(), arity, "invalid constraint: arity mismatch");
+        let arity = self.args.len();
+        debug_assert_eq!(arity, self.predicate.arity(), "invalid constraint: arity mismatch");
         arity
     }
 

--- a/src/new_api_v04/predicate.rs
+++ b/src/new_api_v04/predicate.rs
@@ -38,6 +38,12 @@ impl<AP: AssignPredicate, FP: FilterPredicate> Predicate<AP, FP> {
     }
 }
 
+/// A predicate with a fixed arity N.
+pub trait ArityPredicate {
+    /// Get Predicate arity
+    fn arity(&self) -> usize;
+}
+
 /// A N-ary predicate that can be queried to return valid RHS bindings.
 ///
 /// A predicate of the form `<var1>, <var2> ... pred <varN>`. Given a binding
@@ -45,14 +51,11 @@ impl<AP: AssignPredicate, FP: FilterPredicate> Predicate<AP, FP> {
 /// <varN> for the given input data.
 ///
 /// The arity N of an assign predicate must be N >= 1.
-pub trait AssignPredicate {
+pub trait AssignPredicate: ArityPredicate {
     /// The universe of valid symbols in the problem domain
     type U;
     /// The input data type in the problem domain.
     type D;
-
-    /// Get Predicate arity
-    fn arity(&self) -> usize;
 
     /// Find set of variable assignments that satisfy the predicate.
     ///
@@ -64,14 +67,11 @@ pub trait AssignPredicate {
 ///
 /// A predicate of the form `<var1>, <var2> ... pred <varN>`. Given bindings for
 /// <var1> to <varN>, the predicate checks if it's satisfied on those values.
-pub trait FilterPredicate {
+pub trait FilterPredicate: ArityPredicate {
     /// The universe of valid symbols in the problem domain.
     type U;
     /// The input data type in the problem domain.
     type D;
-
-    /// Get Predicate arity
-    fn arity(&self) -> usize;
 
     /// Check if the predicate is satisfied by the given data and values.
     ///
@@ -87,10 +87,6 @@ where
     type U = T::U;
 
     type D = T::D;
-
-    fn arity(&self) -> usize {
-        self.arity()
-    }
 
     fn check(&self, data: &Self::D, args: &[&Self::U]) -> bool {
         assert!(self.arity() >= 1, "AssignPredicate arity must be >= 1");

--- a/src/new_api_v04/predicate.rs
+++ b/src/new_api_v04/predicate.rs
@@ -18,7 +18,7 @@
 //! `FilterPredicate` by calling `assign_check` and then checking that the binding
 //! for <var2> is in the returned set.
 
-use std::collections::HashSet;
+use crate::HashSet;
 use std::hash::Hash;
 
 /// A predicate for pattern matching.

--- a/src/new_api_v04/predicate.rs
+++ b/src/new_api_v04/predicate.rs
@@ -28,33 +28,55 @@ pub enum Predicate<AP, FP> {
     Filter(FP),
 }
 
-/// A binary predicate that can be queried to return valid RHS bindings.
+impl<AP: AssignPredicate, FP: FilterPredicate> Predicate<AP, FP> {
+    /// Get Predicate arity
+    pub fn arity(&self) -> usize {
+        match self {
+            Predicate::Assign(ap) => ap.arity(),
+            Predicate::Filter(fp) => fp.arity(),
+        }
+    }
+}
+
+/// A N-ary predicate that can be queried to return valid RHS bindings.
 ///
-/// A predicate of the form `<var1> pred <var2>`. Given a binding for <var1>,
-/// the predicate can return a set of valid values for <var2> for the given
-/// input data.
+/// A predicate of the form `<var1>, <var2> ... pred <varN>`. Given a binding
+/// for <var1> to <varN-1>, the predicate returns a set of valid values for
+/// <varN> for the given input data.
+///
+/// The arity N of an assign predicate must be N >= 1.
 pub trait AssignPredicate {
     /// The universe of valid symbols in the problem domain
     type U;
     /// The input data type in the problem domain.
     type D;
 
+    /// Get Predicate arity
+    fn arity(&self) -> usize;
+
     /// Find set of variable assignments that satisfy the predicate.
-    fn check_assign(&self, data: &Self::D, value: &Self::U) -> HashSet<Self::U>;
+    ///
+    /// `values` must be of length `arity() - 1`.
+    fn check_assign(&self, data: &Self::D, args: &[&Self::U]) -> HashSet<Self::U>;
 }
 
-/// A binary predicate for a given data and variable bindings.
+/// A N-ary predicate for a given data and variable bindings.
 ///
-/// A predicate of the form `<var1> pred <var2>`. Given bindings for <var1>
-/// and <var2> the predicate can check if it's satisfied on those values.
+/// A predicate of the form `<var1>, <var2> ... pred <varN>`. Given bindings for
+/// <var1> to <varN>, the predicate checks if it's satisfied on those values.
 pub trait FilterPredicate {
     /// The universe of valid symbols in the problem domain.
     type U;
     /// The input data type in the problem domain.
     type D;
 
+    /// Get Predicate arity
+    fn arity(&self) -> usize;
+
     /// Check if the predicate is satisfied by the given data and values.
-    fn check(&self, data: &Self::D, value1: &Self::U, value2: &Self::U) -> bool;
+    ///
+    /// `values` must be of length `arity()`.
+    fn check(&self, data: &Self::D, args: &[&Self::U]) -> bool;
 }
 
 impl<T> FilterPredicate for T
@@ -66,7 +88,15 @@ where
 
     type D = T::D;
 
-    fn check(&self, data: &Self::D, value1: &Self::U, value2: &Self::U) -> bool {
-        self.check_assign(data, value1).contains(value2)
+    fn arity(&self) -> usize {
+        self.arity()
+    }
+
+    fn check(&self, data: &Self::D, args: &[&Self::U]) -> bool {
+        assert!(self.arity() >= 1, "AssignPredicate arity must be >= 1");
+        assert_eq!(args.len(), self.arity(), "invalid predicate data");
+
+        self.check_assign(data, &args[..self.arity() - 1])
+            .contains(&args[self.arity() - 1])
     }
 }

--- a/src/new_api_v04/predicate.rs
+++ b/src/new_api_v04/predicate.rs
@@ -97,6 +97,6 @@ where
         assert_eq!(args.len(), self.arity(), "invalid predicate data");
 
         self.check_assign(data, &args[..self.arity() - 1])
-            .contains(&args[self.arity() - 1])
+            .contains(args[self.arity() - 1])
     }
 }

--- a/src/new_api_v04/variable.rs
+++ b/src/new_api_v04/variable.rs
@@ -6,17 +6,43 @@
 //! The bindings are stored and retrieve in a map-like struct that implements
 //! the [VariableScope] trait.
 
+use crate::HashMap;
+use std::{fmt::Debug, hash::Hash};
+use thiserror::Error;
+
 /// Errors that occur when binding variables in scope.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Error)]
 pub enum BindVariableError {
     /// A variable already exists in the scope.
-    VariableExists,
+    #[error("Cannot bind variable {0}: already exists")]
+    VariableExists(String),
+
     /// A value is already bound to another variable in scope.
-    ValueExists,
+    #[error("Cannot bind value {value} to variable {variable}: value already exists")]
+    ValueExists {
+        /// The value that already exists
+        value: String,
+        /// The variable binding the value to
+        variable: String,
+    },
 }
 
 /// A map-like trait for variable bindings.
 pub trait VariableScope<V, U> {
     fn get(&self, var: &V) -> Option<&U>;
-    fn bind(&mut self, var: &V, val: U) -> Result<(), BindVariableError>;
+    fn bind(&mut self, var: V, val: U) -> Result<(), BindVariableError>;
+}
+
+impl<V: Hash + Eq + Debug, U> VariableScope<V, U> for HashMap<V, U> {
+    fn get(&self, var: &V) -> Option<&U> {
+        self.get(var)
+    }
+
+    fn bind(&mut self, var: V, val: U) -> Result<(), BindVariableError> {
+        if self.contains_key(&var) {
+            return Err(BindVariableError::VariableExists(format!("{:?}", var)));
+        }
+        self.insert(var, val);
+        Ok(())
+    }
 }


### PR DESCRIPTION
Now predicates & constraints can be of arbitrary arity.

This is a creative solution to @aborgna-q's previous [comment](https://github.com/lmondada/portmatching/pull/42#discussion_r1585137357) that constraint arguments might not be of the same type.

> Actually having different universe types is messy, because that would require different variable to universe scope maps and creates a whole series of type checking problems.
>
> Instead, I suggest the interface should support is unary (and in general n-ary) predicates. So if the predicate is a binary predicate with a constant rhs, it should just be defined as unary predicate.
>
> If it really is the case that variables can be of more than one type, then the user should use enums and handle type checking themselves.