### PR TITLE
chore(utils): Add online toposort and graph tracer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,8 @@ serde = "1.0.156"
 serde_json = "1.0.96"
 glob = "0.3.1"
 criterion = { version = "0.4.0", features = ["html_reports"] }
+rstest = "0.21.0"
+insta = "1.39.0"
 
 [dev-dependencies.portgraph]
 features = ["proptest", "serde"]

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -4,8 +4,12 @@
 pub(crate) mod test;
 
 mod connected_components;
+mod toposort;
+mod tracer;
+
 pub use connected_components::{connected_components, is_connected};
 use portgraph::{LinkView, NodeIndex, SecondaryMap};
+pub(crate) use toposort::online_toposort;
 
 use crate::{patterns::UnweightedEdge, WeightedGraphRef};
 

--- a/src/utils/snapshots/portmatching__utils__tracer__tests__tracer.snap
+++ b/src/utils/snapshots/portmatching__utils__tracer__tests__tracer.snap
@@ -1,0 +1,26 @@
+---
+source: src/utils/tracer.rs
+assertion_line: 319
+expression: tracer.dot_string()
+---
+digraph {
+    0 [ label = "State(0)" ]
+    1 [ label = "Terminal" ]
+    2 [ label = "State(2)" ]
+    3 [ label = "State(3)" ]
+    4 [ label = "State(5)" ]
+    5 [ label = "State(1)" ]
+    6 [ label = "State(2)" ]
+    7 [ label = "State(3)" ]
+    8 [ label = "State(7)" ]
+    0 -> 2 [ label = "ExistingEdge(())" ]
+    2 -> 3 [ label = "ExistingEdge(())" ]
+    3 -> 1 [ label = "NewEdge { to: 6, weight: () }" ]
+    2 -> 4 [ label = "ExistingEdge(())" ]
+    4 -> 1 [ label = "NewEdge { to: 66, weight: () }" ]
+    0 -> 5 [ label = "ExistingEdge(())" ]
+    5 -> 6 [ label = "ExistingEdge(())" ]
+    6 -> 7 [ label = "ExistingEdge(())" ]
+    7 -> 1 [ label = "NewEdge { to: 6, weight: () }" ]
+    0 -> 8 [ label = "ExistingEdge(())" ]
+}

--- a/src/utils/snapshots/portmatching__utils__tracer__tests__tracer_zip.snap
+++ b/src/utils/snapshots/portmatching__utils__tracer__tests__tracer_zip.snap
@@ -1,6 +1,6 @@
 ---
 source: src/utils/tracer.rs
-assertion_line: 327
+assertion_line: 354
 expression: tracer.dot_string()
 ---
 digraph {
@@ -12,11 +12,11 @@ digraph {
     6 [ label = "State(2)" ]
     7 [ label = "State(3)" ]
     0 -> 2 [ label = "ExistingEdge(())" ]
-    2 -> 7 [ label = "ExistingEdge(())" ]
     2 -> 4 [ label = "ExistingEdge(())" ]
     4 -> 1 [ label = "NewEdge { to: 66, weight: () }" ]
     0 -> 5 [ label = "ExistingEdge(())" ]
     5 -> 6 [ label = "ExistingEdge(())" ]
     6 -> 7 [ label = "ExistingEdge(())" ]
     7 -> 1 [ label = "NewEdge { to: 6, weight: () }" ]
+    2 -> 7 [ label = "ExistingEdge(())" ]
 }

--- a/src/utils/snapshots/portmatching__utils__tracer__tests__tracer_zip.snap
+++ b/src/utils/snapshots/portmatching__utils__tracer__tests__tracer_zip.snap
@@ -1,0 +1,22 @@
+---
+source: src/utils/tracer.rs
+assertion_line: 327
+expression: tracer.dot_string()
+---
+digraph {
+    0 [ label = "State(0)" ]
+    1 [ label = "Terminal" ]
+    2 [ label = "State(2)" ]
+    4 [ label = "State(5)" ]
+    5 [ label = "State(1)" ]
+    6 [ label = "State(2)" ]
+    7 [ label = "State(3)" ]
+    0 -> 2 [ label = "ExistingEdge(())" ]
+    2 -> 7 [ label = "ExistingEdge(())" ]
+    2 -> 4 [ label = "ExistingEdge(())" ]
+    4 -> 1 [ label = "NewEdge { to: 66, weight: () }" ]
+    0 -> 5 [ label = "ExistingEdge(())" ]
+    5 -> 6 [ label = "ExistingEdge(())" ]
+    6 -> 7 [ label = "ExistingEdge(())" ]
+    7 -> 1 [ label = "NewEdge { to: 6, weight: () }" ]
+}

--- a/src/utils/snapshots/portmatching__utils__tracer__tests__zip_parallel.snap
+++ b/src/utils/snapshots/portmatching__utils__tracer__tests__zip_parallel.snap
@@ -1,0 +1,13 @@
+---
+source: src/utils/tracer.rs
+assertion_line: 362
+expression: tracer_parallel.dot_string()
+---
+digraph {
+    0 [ label = "State(0)" ]
+    1 [ label = "Terminal" ]
+    3 [ label = "State(1)" ]
+    0 -> 3 [ label = "ExistingEdge(())" ]
+    3 -> 1 [ label = "NewEdge { to: 2, weight: () }" ]
+    0 -> 3 [ label = "ExistingEdge(())" ]
+}

--- a/src/utils/toposort.rs
+++ b/src/utils/toposort.rs
@@ -1,25 +1,95 @@
-use std::collections::BTreeSet;
+#![allow(dead_code)] // Temporary until refactor is complete
 
-use portgraph::{algorithms as pg, Direction, NodeIndex, PortGraph, UnmanagedDenseMap};
+use std::hash::Hash;
 
-/// Topological sorting of the graph
+use petgraph::{visit::IntoNeighborsDirected, Direction};
+
+use crate::HashSet;
+
+/// Perform a topological sort of a graph, without reference to it.
 ///
-/// Unlike `portgraph::algorithms::toposort`, this function traverses all
-/// descendants of the root node.
-pub(crate) fn toposort(g: &PortGraph, root: NodeIndex) -> impl Iterator<Item = NodeIndex> + '_ {
-    let desc = pg::postorder(g, [root], Direction::Outgoing).collect::<BTreeSet<_>>();
-    let port_filter = move |_, p| {
-        if g.port_direction(p).expect("invalid port") == Direction::Outgoing {
-            return true;
+/// This will only traverse the descendants of `root`.
+///
+/// Graph mutations of parts of the graph that have not been visited yet are
+/// allowed during the traversal.
+///
+/// If you delete edges or change the graph in other ways, the behaviour
+/// is undefined.
+pub fn online_toposort<N: Eq + Hash + Copy>(root: N) -> OnlineToposort<N> {
+    OnlineToposort::new(root)
+}
+
+/// Iterator for online topological traversal of a graph.
+pub struct OnlineToposort<N> {
+    /// Nodes that have been visited
+    visited: HashSet<N>,
+    /// Stack of nodes that are ready to be visited (all predecessors have
+    /// been visited)
+    to_visit_next: Vec<N>,
+    /// Nodes that have been visited but whose children have not yet been visited
+    ///
+    /// We delay processing the outgoing edges of these nodes as long as possible,
+    /// to allow for graph edits.
+    pending_children: Vec<N>,
+}
+
+impl<N: Eq + Hash + Copy> OnlineToposort<N> {
+    fn new(root: N) -> Self {
+        Self {
+            visited: HashSet::default(),
+            to_visit_next: vec![root],
+            pending_children: vec![],
         }
-        let Some(link) = g.port_link(p) else { return true };
-        desc.contains(&g.port_node(link).expect("invalid port"))
-    };
-    pg::toposort_filtered::<UnmanagedDenseMap<_, _>>(
-        g,
-        [root],
-        Direction::Outgoing,
-        |_| true,
-        port_filter,
-    )
+    }
+
+    pub fn next<G: IntoNeighborsDirected<NodeId = N>>(&mut self, graph: G) -> Option<N> {
+        while self.to_visit_next.is_empty() {
+            // We must process some pending nodes
+            let pending_node = self.pending_children.pop()?;
+            for child in graph.neighbors_directed(pending_node, Direction::Outgoing) {
+                let mut parents = graph.neighbors_directed(child, Direction::Incoming);
+                if parents.all(|p| self.visited.contains(&p)) {
+                    // Only insert if it hasn't been visited yet nor is it queued to be
+                    if !self.visited.contains(&child) && !self.to_visit_next.contains(&child) {
+                        self.to_visit_next.push(child);
+                    }
+                }
+            }
+        }
+        let next_state = self.to_visit_next.pop()?;
+        self.visited.insert(next_state);
+        self.pending_children.push(next_state);
+
+        Some(next_state)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::iter::from_fn;
+
+    use itertools::Itertools;
+    use petgraph::stable_graph::StableDiGraph;
+    use rstest::{fixture, rstest};
+
+    use super::*;
+
+    #[fixture]
+    fn graph() -> StableDiGraph<usize, ()> {
+        let mut graph = StableDiGraph::new();
+        let nodes = (0..4).map(|i| graph.add_node(i)).collect_vec();
+        graph.add_edge(nodes[0], nodes[2], ());
+        graph.add_edge(nodes[2], nodes[3], ());
+        graph.add_edge(nodes[3], nodes[1], ());
+        graph
+    }
+
+    #[rstest]
+    fn test_online_toposort(graph: StableDiGraph<usize, ()>) {
+        let mut toposort = online_toposort(0.into());
+        assert_eq!(
+            from_fn(|| toposort.next(&graph)).collect_vec(),
+            vec![0.into(), 2.into(), 3.into(), 1.into()]
+        );
+    }
 }

--- a/src/utils/toposort.rs
+++ b/src/utils/toposort.rs
@@ -14,7 +14,7 @@ use crate::HashSet;
 /// The particularity of this implemention is that graph mutations during
 /// traversal are supported, as long as node indices are stable. As a tradeoff,
 /// this traversal is not particularly efficient: each call to `next` may take
-/// up to time O(V + E).
+/// up to O(V + E) time.
 ///
 /// ## Supported graph modifications
 ///

--- a/src/utils/toposort.rs
+++ b/src/utils/toposort.rs
@@ -7,7 +7,7 @@ use petgraph::{visit::IntoNeighborsDirected, Direction};
 
 use crate::HashSet;
 
-/// Perform a topological sort of a graph, without reference to it.
+/// Perform a topological sort of a graph, without keeping a reference to it.
 ///
 /// This will only traverse the descendants of `root`.
 ///

--- a/src/utils/toposort.rs
+++ b/src/utils/toposort.rs
@@ -7,9 +7,10 @@ use petgraph::{visit::IntoNeighborsDirected, Direction};
 
 use crate::HashSet;
 
-/// Perform a topological sort of a graph, without keeping a reference to it.
+/// Perform a topological sort of a graph, while allowing graph mutations.
 ///
-/// This will only traverse the descendants of `root`.
+/// The graph is expected to be acyclic and all nodes must be reachable from the
+/// root (i.e. the root is the source of the graph).
 ///
 /// The particularity of this implemention is that graph mutations during
 /// traversal are supported, as long as node indices are stable. As a tradeoff,

--- a/src/utils/toposort.rs
+++ b/src/utils/toposort.rs
@@ -2,6 +2,7 @@
 
 use std::hash::Hash;
 
+use itertools::Itertools;
 use petgraph::{visit::IntoNeighborsDirected, Direction};
 
 use crate::HashSet;
@@ -10,27 +11,37 @@ use crate::HashSet;
 ///
 /// This will only traverse the descendants of `root`.
 ///
-/// Graph mutations of parts of the graph that have not been visited yet are
-/// allowed during the traversal.
+/// The particularity of this implemention is that graph mutations during
+/// traversal are supported, as long as node indices are stable. As a tradeoff,
+/// this traversal is not particularly efficient: each call to `next` may take
+/// up to time O(V + E).
 ///
-/// If you delete edges or change the graph in other ways, the behaviour
-/// is undefined.
+/// ## Supported graph modifications
+///
+/// Edge and vertex additions are always supported, and as long as additional
+/// edges do not invalidate the topological ordering of the nodes already
+/// emitted, the result will be a valid topological order of the final graph.
+///
+/// Similarly, node and edges deletions are supported and the resulting topological
+/// ordering will be a valid order of the initial graph (and thus of the final
+/// graph too), as long as the edges do not disconnect the graph (more precisely
+/// the connected component that the `root` is in).
 pub fn online_toposort<N: Eq + Hash + Copy>(root: N) -> OnlineToposort<N> {
     OnlineToposort::new(root)
 }
 
-/// Iterator for online topological traversal of a graph.
 pub struct OnlineToposort<N> {
     /// Nodes that have been visited
     visited: HashSet<N>,
-    /// Stack of nodes that are ready to be visited (all predecessors have
-    /// been visited)
-    to_visit_next: Vec<N>,
-    /// Nodes that have been visited but whose children have not yet been visited
+    /// Stack of nodes that were ready to be visited when last seen.
     ///
-    /// We delay processing the outgoing edges of these nodes as long as possible,
-    /// to allow for graph edits.
-    pending_children: Vec<N>,
+    /// Before outputting these nodes, it should be checked again that
+    /// they are ready, in case the graph changed.
+    ///
+    /// In theory we could make do without this and recompute our options at
+    /// every `next` call, but we choose to keep a short stack of valid choices
+    /// to speed up successive calls.
+    to_visit_next: Vec<N>,
 }
 
 impl<N: Eq + Hash + Copy> OnlineToposort<N> {
@@ -38,30 +49,59 @@ impl<N: Eq + Hash + Copy> OnlineToposort<N> {
         Self {
             visited: HashSet::default(),
             to_visit_next: vec![root],
-            pending_children: vec![],
         }
     }
 
+    /// A node whose predecessors have all been visited
+    fn is_ready<G: IntoNeighborsDirected<NodeId = N>>(&self, node: N, graph: &G) -> bool {
+        node_is_ready(node, graph, &self.visited)
+    }
+
+    /// Remove previously ready nodes that are no longer ready (due to changes to the graph)
+    fn prune_unready<G: IntoNeighborsDirected<NodeId = N>>(&mut self, graph: &G) {
+        let Self {
+            visited,
+            to_visit_next,
+        } = self;
+        to_visit_next.retain(|&n| node_is_ready(n, graph, visited));
+    }
+
+    /// A node that is either queued to be visited, or has been visited
+    fn is_queued_or_visited(&self, node: N) -> bool {
+        self.to_visit_next.contains(&node) || self.visited.contains(&node)
+    }
+
+    /// Get the next node to visit, or None if no unvisited node can be reached.
     pub fn next<G: IntoNeighborsDirected<NodeId = N>>(&mut self, graph: G) -> Option<N> {
+        // Make sure our ready nodes are still currently ready
+        self.prune_unready(&graph);
+
+        // Refill supply of ready nodes if empty
+        let mut all_visited = self.visited.iter().copied();
         while self.to_visit_next.is_empty() {
-            // We must process some pending nodes
-            let pending_node = self.pending_children.pop()?;
-            for child in graph.neighbors_directed(pending_node, Direction::Outgoing) {
-                let mut parents = graph.neighbors_directed(child, Direction::Incoming);
-                if parents.all(|p| self.visited.contains(&p)) {
-                    // Only insert if it hasn't been visited yet nor is it queued to be
-                    if !self.visited.contains(&child) && !self.to_visit_next.contains(&child) {
-                        self.to_visit_next.push(child);
-                    }
-                }
-            }
+            let ready_nodes = graph
+                .neighbors_directed(all_visited.next()?, Direction::Outgoing)
+                .filter(|&n| self.is_ready(n, &graph))
+                .filter(|&n| !self.is_queued_or_visited(n))
+                .unique()
+                .collect_vec();
+            self.to_visit_next.extend(ready_nodes);
         }
+
         let next_state = self.to_visit_next.pop()?;
         self.visited.insert(next_state);
-        self.pending_children.push(next_state);
-
         Some(next_state)
     }
+}
+
+fn node_is_ready<N, G>(node: N, graph: G, visited: &HashSet<N>) -> bool
+where
+    N: Eq + Hash + Copy,
+    G: IntoNeighborsDirected<NodeId = N>,
+{
+    graph
+        .neighbors_directed(node, Direction::Incoming)
+        .all(|p| visited.contains(&p))
 }
 
 #[cfg(test)]
@@ -69,11 +109,12 @@ mod tests {
     use std::iter::from_fn;
 
     use itertools::Itertools;
-    use petgraph::stable_graph::StableDiGraph;
+    use petgraph::{stable_graph::StableDiGraph, visit::EdgeRef};
     use rstest::{fixture, rstest};
 
     use super::*;
 
+    /// 0 -> 2 -> 3 -> 1
     #[fixture]
     fn graph() -> StableDiGraph<usize, ()> {
         let mut graph = StableDiGraph::new();
@@ -90,6 +131,57 @@ mod tests {
         assert_eq!(
             from_fn(|| toposort.next(&graph)).collect_vec(),
             vec![0.into(), 2.into(), 3.into(), 1.into()]
+        );
+    }
+
+    #[rstest]
+    fn test_online_toposort_with_live_changes(mut graph: StableDiGraph<usize, ()>) {
+        let mut toposort = online_toposort(0.into());
+        assert_eq!(
+            from_fn(|| toposort.next(&graph)).take(3).collect_vec(),
+            vec![0.into(), 2.into(), 3.into()]
+        );
+
+        // Now delete edge 3 -> 1 and instead add edge 2 -> 1
+        let edge_3_1 = graph
+            .edges_connecting(3.into(), 1.into())
+            .exactly_one()
+            .unwrap();
+        graph.remove_edge(edge_3_1.id());
+        graph.add_edge(2.into(), 1.into(), ());
+        assert_eq!(toposort.next(&graph), Some(1.into()));
+
+        // And finally, create a new node and link it to 0
+        let node_4 = graph.add_node(4);
+        graph.add_edge(0.into(), node_4, ());
+        assert_eq!(toposort.next(&graph), Some(4.into()));
+        assert_eq!(toposort.next(&graph), None);
+    }
+
+    #[test]
+    fn test_disconnected() {
+        let mut graph = StableDiGraph::<usize, ()>::new();
+        (0..3).for_each(|i| {
+            graph.add_node(i);
+        });
+        graph.add_edge(0.into(), 1.into(), ());
+        let mut toposort = online_toposort(2.into());
+        assert_eq!(toposort.next(&graph), Some(2.into()));
+        assert_eq!(toposort.next(&graph), None);
+    }
+
+    #[test]
+    fn test_parallel() {
+        let mut graph = StableDiGraph::<usize, ()>::new();
+        (0..2).for_each(|i| {
+            graph.add_node(i);
+        });
+        graph.add_edge(0.into(), 1.into(), ());
+        graph.add_edge(0.into(), 1.into(), ());
+        let mut toposort = online_toposort(0.into());
+        assert_eq!(
+            from_fn(|| toposort.next(&graph)).collect_vec(),
+            vec![0.into(), 1.into()]
         );
     }
 }

--- a/src/utils/tracer.rs
+++ b/src/utils/tracer.rs
@@ -259,7 +259,7 @@ fn partition_children<N: Eq + Ord, E: Eq>(
     graph
         .neighbors_directed(node, Direction::Outgoing)
         // This sorting may miss some of the grouping possibilities, but the tradeoff
-        // would be to require C: Ord
+        // would be to require E: Ord
         .sorted_by_key(|child| key_of(*child).0)
         .group_by(|child| key_of(*child))
         .into_iter()

--- a/src/utils/tracer.rs
+++ b/src/utils/tracer.rs
@@ -1,0 +1,329 @@
+#![allow(dead_code)] // Temporary until refactor is complete
+
+use std::fmt::Debug;
+
+use derive_more::{From, Into};
+use itertools::Itertools;
+use petgraph::{
+    algo::toposort,
+    dot::Dot,
+    graph::{EdgeIndex, NodeIndex},
+    stable_graph::StableDiGraph,
+    visit::{Bfs, EdgeRef},
+    Direction,
+};
+
+use crate::{utils::online_toposort, HashSet};
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+enum TracerNodeWeight<NodeId> {
+    State(NodeId),
+    Terminal,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum TracerEdgeWeight<NodeId, EdgeId, EdgeWeight> {
+    ExistingEdge(EdgeId),
+    NewEdge { to: NodeId, weight: EdgeWeight },
+}
+
+/// A handle to a traced node.
+///
+/// A handle to such a node is obtained by tracing edge traversals from another
+/// traced node (or the initial traced node).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, From, Into)]
+pub struct TracedNode(NodeIndex);
+
+/// A handle to a traced edge.
+///
+/// A handle to such an edge is obtained by tracing an edge traversal.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, From, Into)]
+pub struct TracedEdge(EdgeIndex);
+
+/// Trace edge traversals and additions in a graph.
+///
+/// Starting from an `initial_node`, keep track of edges traversed. This creates
+/// traced nodes and traced paths through the graph starting at `initial_node`.
+///
+/// There is always a graph homomorphism from the traced graph into the underlying
+/// graph. However, this map is not injective: multiple traversals of the same
+/// path in the underlying graph will result in multiple traced paths in the
+/// traced graph.
+///
+/// New edges can be added at traced nodes, creating traced edge additions. This
+/// can be used to delay edge additions until after a larger graph operation
+/// is completed. This is useful in state automata, as we can ensure that new
+/// transitions can extend traced paths without changing the states reachable
+/// along non-traced paths.
+///
+/// The target of edge additions is always an untraced node. Internally, we store
+/// them as edges to a terminal node.
+pub struct Tracer<NodeId, EdgeId, EdgeWeight> {
+    /// The edges that have been traversed and traced
+    ///
+    /// The only edges with a `NewEdge` weight are the ones with target at the terminal.
+    trace: StableDiGraph<TracerNodeWeight<NodeId>, TracerEdgeWeight<NodeId, EdgeId, EdgeWeight>>,
+    /// The initial node, from which all other nodes must be reachable.
+    initial_node: TracedNode,
+    /// The terminal node, to which all `NewEdge` connect to.
+    terminal_node: TracedNode,
+}
+
+impl<NodeId, EdgeId, EdgeWeight> Tracer<NodeId, EdgeId, EdgeWeight>
+where
+    NodeId: Copy + Eq + Ord,
+    EdgeId: Copy + Eq + Ord,
+    EdgeWeight: Eq,
+{
+    /// Create a new tracer for paths starting in `initial_node`.
+    pub fn new(initial_node: NodeId) -> Self {
+        let mut trace = StableDiGraph::new();
+        let initial_node = trace.add_node(TracerNodeWeight::State(initial_node)).into();
+        let terminal_node = trace.add_node(TracerNodeWeight::Terminal).into();
+        Tracer {
+            trace,
+            initial_node,
+            terminal_node,
+        }
+    }
+
+    /// Handle to the initial node in the tracer.
+    pub fn initial_node(&self) -> TracedNode {
+        self.initial_node
+    }
+
+    /// Iterate over all nodes in the traced graph in topological order.
+    pub fn toposort(&self) -> impl Iterator<Item = TracedNode> {
+        toposort(&self.trace, None)
+            .unwrap()
+            .into_iter()
+            .map(|n| n.into())
+    }
+
+    /// The node underlying a traced handle.
+    pub fn node(&self, node: TracedNode) -> Option<NodeId> {
+        match *self.trace.node_weight(node.into())? {
+            TracerNodeWeight::State(s) => Some(s),
+            TracerNodeWeight::Terminal => None,
+        }
+    }
+
+    /// All traced incoming edges to a traced node.
+    pub fn traced_incoming(&self, node: TracedNode) -> impl Iterator<Item = EdgeId> + '_ {
+        self.trace
+            .edges_directed(node.into(), Direction::Incoming)
+            .map(|e| self.edge(e.id().into()).unwrap())
+    }
+
+    /// Consume the tracer and return all traced edge additions.
+    pub fn into_edge_additions(mut self) -> impl Iterator<Item = (NodeId, NodeId, EdgeWeight)> {
+        let edge_adds = self
+            .trace
+            .edges_directed(self.terminal_node.into(), Direction::Incoming)
+            .map(|e| e.id())
+            .collect_vec();
+        edge_adds.into_iter().map(move |edge_id| {
+            let from_node = self.trace.edge_endpoints(edge_id).unwrap().0;
+            let from = self.node(from_node.into()).unwrap();
+            let TracerEdgeWeight::NewEdge { to, weight } = self.trace.remove_edge(edge_id).unwrap()
+            else {
+                panic!("Edge connected to terminal node");
+            };
+            (from, to, weight)
+        })
+    }
+
+    /// The edge underlying a traced handle.
+    pub fn edge(&self, edge: TracedEdge) -> Option<EdgeId> {
+        match *self.trace.edge_weight(edge.into())? {
+            TracerEdgeWeight::ExistingEdge(t) => Some(t),
+            TracerEdgeWeight::NewEdge { .. } => None,
+        }
+    }
+
+    /// Trace an edge traversal and return the target as a new traced node.
+    pub fn traverse_edge(
+        &mut self,
+        transition: EdgeId,
+        from_node: TracedNode,
+        to_state: NodeId,
+    ) -> TracedNode {
+        let to_node = self.trace.add_node(TracerNodeWeight::State(to_state));
+        self.trace.add_edge(
+            from_node.into(),
+            to_node,
+            TracerEdgeWeight::ExistingEdge(transition),
+        );
+        to_node.into()
+    }
+
+    /// Trace an edge addition to an untraced node.
+    ///
+    /// Use this to delay edge addition in the underlying graph. Recover all
+    /// traced additions at the end of tracing using [`into_edge_additions`](Self::into_edge_additions).
+    pub fn add_edge(&mut self, constraint: EdgeWeight, from_node: TracedNode, to_state: NodeId) {
+        let to_node = self.terminal_node;
+        self.trace.add_edge(
+            from_node.into(),
+            to_node.into(),
+            TracerEdgeWeight::NewEdge {
+                to: to_state,
+                weight: constraint,
+            },
+        );
+    }
+
+    /// Merge identical traced nodes and edges starting from terminal.
+    ///
+    /// The aim of this is to reduce the size of the traced graph, and in
+    /// particular the number of edge additions. This is achieved by finding
+    /// subgraphs of the trace that are identical (and hence map to the same
+    /// subgraph of the underlying graph) and merging them.
+    ///
+    /// This also prunes any nodes that are not reachable from terminal, as they
+    /// are irrelevant for edge additions.
+    pub fn zip(&mut self) {
+        // We will proceed from terminal to root (un-reverse at the end)
+        self.trace.reverse();
+
+        // First prune the graph of any node that is not reachable from terminal.
+        prune_unreachable(self.terminal_node.into(), &mut self.trace);
+
+        // Now starting from terminal, merge node where possible
+        let mut traverser = online_toposort(self.terminal_node.into());
+        let mut to_remove = HashSet::default();
+        while let Some(node) = traverser.next(&self.trace) {
+            if to_remove.contains(&node) {
+                continue;
+            }
+            for merge_children in partition_children(node, &self.trace) {
+                let mut merge_children = merge_children.into_iter();
+                let Some(merge_into) = merge_children.next() else {
+                    continue;
+                };
+                for merge_from in merge_children {
+                    merge_nodes(merge_from, merge_into, &mut self.trace);
+                    to_remove.insert(merge_from);
+                }
+            }
+        }
+        for node in to_remove {
+            self.trace.remove_node(node);
+        }
+
+        self.trace.reverse();
+    }
+
+    #[allow(dead_code)]
+    fn dot_string(&self) -> String
+    where
+        NodeId: Debug,
+        EdgeId: Debug,
+        EdgeWeight: Debug,
+    {
+        format!("{:?}", Dot::new(&self.trace))
+    }
+}
+
+/// Partition the children of `node` into sets of identical nodes.
+///
+/// Two nodes are "identical" if they have the same node weight and
+/// the same set of incoming edges, each with identical edge source and edge weight.
+fn partition_children<N: Eq + Ord, E: Eq>(
+    node: NodeIndex,
+    graph: &StableDiGraph<N, E>,
+) -> Vec<Vec<NodeIndex>> {
+    let key_of = |child| {
+        (
+            graph.node_weight(child).unwrap(),
+            graph
+                .edges_directed(child, Direction::Incoming)
+                .map(|e| (graph.edge_weight(e.id()).unwrap(), e.source()))
+                .sorted_by_key(|&(_, k)| k)
+                .collect_vec(),
+        )
+    };
+    graph
+        .neighbors_directed(node, Direction::Outgoing)
+        // This sorting may miss some of the grouping possibilities, but the tradeoff
+        // would be to require C: Ord
+        .sorted_by_key(|child| key_of(*child).0)
+        .group_by(|child| key_of(*child))
+        .into_iter()
+        .map(|(_, indices)| indices.collect_vec())
+        .collect_vec()
+}
+
+/// Merge the node `merge_from` into `merge_into`, transfering all outgoing edges.
+///
+/// Remove all outgoing edges of `merge_from` but not the node itself. The caller
+/// should remove it when appropriate.
+fn merge_nodes<N: Eq, E: Eq>(
+    merge_from: NodeIndex,
+    merge_into: NodeIndex,
+    graph: &mut StableDiGraph<N, E>,
+) {
+    let from_out = graph
+        .edges_directed(merge_from, Direction::Outgoing)
+        .map(|e| (e.id(), e.target()))
+        .collect_vec();
+    for (edge_id, edge_target) in from_out {
+        let edge_weight = graph.remove_edge(edge_id).unwrap();
+        graph.add_edge(merge_into, edge_target, edge_weight);
+    }
+}
+
+fn prune_unreachable<N, E>(node: NodeIndex, graph: &mut StableDiGraph<N, E>) {
+    let mut visited = HashSet::default();
+    let mut bfs = Bfs::new(&*graph, node);
+    while let Some(node) = bfs.next(&*graph) {
+        visited.insert(node);
+    }
+    let mut to_remove = graph.node_indices().collect_vec();
+    to_remove.retain(|n| !visited.contains(n));
+
+    for node in to_remove {
+        graph.remove_node(node);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use rstest::{fixture, rstest};
+
+    #[fixture]
+    fn tracer() -> Tracer<usize, (), ()> {
+        // Trace paths starting at 0 (of some graph we don't build)
+        let mut tracer = Tracer::new(0);
+        // Traverse 0 -> 2 -> 3, then add 3 -> 6
+        let traced_2 = tracer.traverse_edge((), tracer.initial_node(), 2);
+        let traced_3 = tracer.traverse_edge((), traced_2, 3);
+        tracer.add_edge((), traced_3, 6);
+        // Using the same 0 -> 2, then traverse 2 -> 5, then add 5 -> 66
+        let traced_5 = tracer.traverse_edge((), traced_2, 5);
+        tracer.add_edge((), traced_5, 66);
+        // New traversal 0 -> 1 -> 2 -> 3, then add 3 -> 6
+        let traced_1 = tracer.traverse_edge((), tracer.initial_node(), 1);
+        let traced_2 = tracer.traverse_edge((), traced_1, 2);
+        let traced_3 = tracer.traverse_edge((), traced_2, 3);
+        tracer.add_edge((), traced_3, 6);
+        // New traversal 0 -> 7, no edge addition
+        tracer.traverse_edge((), tracer.initial_node(), 7);
+        tracer
+    }
+
+    #[rstest]
+    fn test_tracer(tracer: Tracer<usize, (), ()>) {
+        insta::assert_snapshot!(tracer.dot_string());
+    }
+
+    #[rstest]
+    fn test_tracer_zip(mut tracer: Tracer<usize, (), ()>) {
+        assert_eq!(tracer.trace.node_count(), 9);
+        tracer.zip();
+        assert_eq!(tracer.trace.node_count(), 7);
+        insta::assert_snapshot!(tracer.dot_string());
+    }
+}


### PR DESCRIPTION
I'm trying to break out parts of my refactor that make sense on their own. This PR contains two graph utilities that I needed. Hopefully they make sense out of context, although I suspect `tracer` might not.