### PR TITLE
feat: Add try_bind_all to IndexingScheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,7 @@ TODO
 ## Features
 
 -   `serde`: Enable serialization and deserialization via serde.
--   `datagen`: Necessary for the [`data_generation`](src/bin/data_generation.rs) binary, for benchmarking. Currently not useful to the end user of
-the crate.
+-   `datagen`: Necessary for the [`data_generation`](src/bin/data_generation.rs) binary, for benchmarking. Currently not useful to the end user of the crate.
 
 
 ## License

--- a/src/indexing/binding_builder.rs
+++ b/src/indexing/binding_builder.rs
@@ -1,0 +1,99 @@
+use std::marker::PhantomData;
+
+use crate::{utils::UniqueStack, HashSet, IndexMap};
+
+use super::{BindVariableError, IndexKey};
+
+pub(super) struct BindingBuilder<K, V, M> {
+    bindings: M,
+    /// A stack of the missing keys.
+    ///
+    /// It's important that we process the keys first-in last-out, to ensure
+    /// that we process the dependencies we added to the stack before processing
+    /// the same key again.
+    missing_keys: UniqueStack<K>,
+    exclude_keys: HashSet<K>,
+    _phantom: PhantomData<V>,
+}
+
+impl<K: Clone, V, M: Clone> Clone for BindingBuilder<K, V, M> {
+    fn clone(&self) -> Self {
+        Self {
+            bindings: self.bindings.clone(),
+            missing_keys: self.missing_keys.clone(),
+            exclude_keys: self.exclude_keys.clone(),
+            _phantom: PhantomData::<V>,
+        }
+    }
+}
+
+impl<K: IndexKey, V, M: IndexMap<K, V>> BindingBuilder<K, V, M> {
+    pub(super) fn new(keys: impl IntoIterator<Item = K>, bindings: M) -> Self {
+        let missing_keys = keys.into_iter().collect();
+        Self {
+            missing_keys,
+            bindings,
+            exclude_keys: HashSet::default(),
+            _phantom: PhantomData::<V>,
+        }
+    }
+
+    pub(super) fn bindings(&self) -> &M {
+        &self.bindings
+    }
+
+    pub(super) fn top_missing_key(&mut self) -> Option<K> {
+        let mut key = *self.missing_keys.top()?;
+        while self.bindings.get(&key).is_some() || self.exclude_keys.contains(&key) {
+            // Already bound or excluded
+            self.missing_keys.pop();
+            key = *self.missing_keys.top()?;
+        }
+        Some(key)
+    }
+
+    pub(super) fn finish(self) -> M {
+        self.bindings
+    }
+
+    pub(super) fn apply_bindings(
+        mut self,
+        key: K,
+        values: impl IntoIterator<Item = V>,
+    ) -> Result<Vec<Self>, BindVariableError> {
+        if self.missing_keys.top() == Some(&key) {
+            self.missing_keys.pop();
+        }
+        values
+            .into_iter()
+            .map(|value| {
+                let mut new_self = self.clone();
+                new_self.bindings.bind(key, value)?;
+                Ok(new_self)
+            })
+            .collect()
+    }
+
+    pub(super) fn exclude_key(&mut self, key: K) {
+        if self.missing_keys.top() == Some(&key) {
+            self.missing_keys.pop();
+        }
+        self.exclude_keys.insert(key);
+    }
+
+    /// Extend the missing key set.
+    ///
+    /// Return whether any key was added.
+    pub(super) fn extend_missing_keys(&mut self, keys: impl IntoIterator<Item = K>) -> bool {
+        let mut to_add = keys
+            .into_iter()
+            .filter(|key| !self.exclude_keys.contains(key))
+            .peekable();
+        if to_add.peek().is_some() {
+            self.missing_keys.extend(to_add);
+            true
+        } else {
+            false
+        }
+    }
+}

--- a/src/indexing/binding_builder.rs
+++ b/src/indexing/binding_builder.rs
@@ -1,4 +1,4 @@
-use std::marker::PhantomData;
+use std::{fmt, marker::PhantomData};
 
 use crate::{utils::UniqueStack, HashSet, IndexMap};
 
@@ -27,8 +27,14 @@ impl<K: Clone, V, M: Clone> Clone for BindingBuilder<K, V, M> {
     }
 }
 
+impl<K, V, M: fmt::Debug> fmt::Debug for BindingBuilder<K, V, M> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "BindingBuilder{:?}", self.bindings)
+    }
+}
+
 impl<K: IndexKey, V, M: IndexMap<K, V>> BindingBuilder<K, V, M> {
-    pub(super) fn new(keys: impl IntoIterator<Item = K>, bindings: M) -> Self {
+    pub fn new(keys: impl IntoIterator<Item = K>, bindings: M) -> Self {
         let missing_keys = keys.into_iter().collect();
         Self {
             missing_keys,
@@ -38,11 +44,11 @@ impl<K: IndexKey, V, M: IndexMap<K, V>> BindingBuilder<K, V, M> {
         }
     }
 
-    pub(super) fn bindings(&self) -> &M {
+    pub fn bindings(&self) -> &M {
         &self.bindings
     }
 
-    pub(super) fn top_missing_key(&mut self) -> Option<K> {
+    pub fn top_missing_key(&mut self) -> Option<K> {
         let mut key = *self.missing_keys.top()?;
         while self.bindings.get(&key).is_some() || self.exclude_keys.contains(&key) {
             // Already bound or excluded
@@ -52,11 +58,11 @@ impl<K: IndexKey, V, M: IndexMap<K, V>> BindingBuilder<K, V, M> {
         Some(key)
     }
 
-    pub(super) fn finish(self) -> M {
+    pub fn finish(self) -> M {
         self.bindings
     }
 
-    pub(super) fn apply_bindings(
+    pub fn apply_bindings(
         mut self,
         key: K,
         values: impl IntoIterator<Item = V>,
@@ -74,7 +80,7 @@ impl<K: IndexKey, V, M: IndexMap<K, V>> BindingBuilder<K, V, M> {
             .collect()
     }
 
-    pub(super) fn exclude_key(&mut self, key: K) {
+    pub fn exclude_key(&mut self, key: K) {
         if self.missing_keys.top() == Some(&key) {
             self.missing_keys.pop();
         }
@@ -84,7 +90,7 @@ impl<K: IndexKey, V, M: IndexMap<K, V>> BindingBuilder<K, V, M> {
     /// Extend the missing key set.
     ///
     /// Return whether any key was added.
-    pub(super) fn extend_missing_keys(&mut self, keys: impl IntoIterator<Item = K>) -> bool {
+    pub fn extend_missing_keys(&mut self, keys: impl IntoIterator<Item = K>) -> bool {
         let mut to_add = keys
             .into_iter()
             .filter(|key| !self.exclude_keys.contains(key))

--- a/src/matcher/single_pattern.rs
+++ b/src/matcher/single_pattern.rs
@@ -8,7 +8,7 @@ use crate::{
     constraint::Constraint,
     indexing::{IndexKey, IndexValue},
     pattern::Pattern,
-    HashMap, IndexMap, IndexingScheme, PatternID, Predicate,
+    HashMap, IndexingScheme, PatternID, Predicate,
 };
 
 use super::{PatternMatch, PortMatcher};
@@ -101,15 +101,15 @@ where
             all_bindings = all_bindings
                 .into_iter()
                 .flat_map(|bindings| {
-                    bindings
-                        .bind_with_scheme(keys.to_vec(), host, &self.host_indexing)
+                    self.host_indexing
+                        .try_bind_all(bindings, keys.to_vec(), host)
                         .unwrap()
                 })
                 .collect();
             candidates.extend(
                 all_bindings
                     .into_iter()
-                    .filter(|bindings| constraint.is_satisfied(host, bindings).unwrap())
+                    .filter(|bindings| constraint.is_satisfied(host, bindings).unwrap_or(false))
                     .map(|bindings| (remaining, bindings)),
             )
         }

--- a/src/mutex_tree.rs
+++ b/src/mutex_tree.rs
@@ -148,6 +148,11 @@ impl<P> MutuallyExclusiveTree<P> {
         self.nodes[node].constraint_indices.push(index);
         Ok(())
     }
+
+    /// The number of nodes in the tree.
+    pub fn n_nodes(&self) -> usize {
+        self.nodes.len()
+    }
 }
 
 /// Constraint indices may not appear on non-leaf nodes.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,6 +7,7 @@ pub(crate) mod mark_last;
 // pub mod test;
 mod toposort;
 pub(crate) mod tracer;
+pub(crate) mod unique_stack;
 
 use itertools::Itertools;
 pub(crate) use mark_last::mark_last;
@@ -16,6 +17,7 @@ pub(crate) use mark_last::mark_last;
 // pub use test::gen_portgraph_connected;
 pub(crate) use toposort::{online_toposort, OnlineToposort};
 pub(crate) use tracer::{TracedNode, Tracer};
+pub(crate) use unique_stack::UniqueStack;
 
 /// Sort a vector and return a vector of pairs of the original value and its position.
 #[allow(dead_code)]

--- a/src/utils/unique_stack.rs
+++ b/src/utils/unique_stack.rs
@@ -1,0 +1,221 @@
+//! A stack that only allows unique elements.
+
+use std::hash::Hash;
+
+use crate::HashMap;
+
+#[derive(Clone)]
+struct El<T> {
+    value: T,
+    below: Option<usize>,
+    above: Option<usize>,
+}
+
+/// Stack with unique elements.
+///
+/// A first in first out stack. If pushing an element that is already
+/// in the stack, the operation moves that element to the top of the stack.
+#[derive(Clone)]
+pub(crate) struct UniqueStack<T> {
+    elements: Vec<Option<El<T>>>,
+    indices: HashMap<T, usize>,
+    top: Option<usize>,
+    free_indices: Vec<usize>,
+}
+
+impl<T: Eq + Hash + Clone> UniqueStack<T> {
+    /// Create a new empty UniqueStack.
+    pub fn new() -> Self {
+        UniqueStack {
+            elements: Vec::new(),
+            indices: HashMap::default(),
+            top: None,
+            free_indices: Vec::new(),
+        }
+    }
+
+    /// Push an element onto the stack, moving it to the top if already present.
+    ///
+    /// Return true if the element was added, false if it was already present.
+    pub fn push(&mut self, value: T) -> bool {
+        if let Some(&index) = self.indices.get(&value) {
+            self.rewire_top(index);
+            false
+        } else {
+            // New element, add it to the top
+            let new_index = self.get_free_index();
+            let el = El {
+                value: value.clone(),
+                below: None,
+                above: None,
+            };
+            self.elements[new_index] = Some(el);
+            self.indices.insert(value, new_index);
+            self.rewire_top(new_index);
+            true
+        }
+    }
+
+    /// Remove and return the top element from the stack.
+    ///
+    /// Return None if the stack is empty.
+    pub fn pop(&mut self) -> Option<T> {
+        let top_index = self.top?;
+        let el = self.elements[top_index].take().unwrap();
+        self.indices.remove(&el.value);
+        self.top = el.below;
+        Some(el.value)
+    }
+
+    /// The top element of the stack without removing it.
+    ///
+    /// Return None if the stack is empty.
+    pub fn top(&self) -> Option<&T> {
+        self.top
+            .map(|index| &self.elements[index].as_ref().unwrap().value)
+    }
+
+    /// A free spot in the vector, creating it if necessary
+    fn get_free_index(&mut self) -> usize {
+        self.free_indices.pop().unwrap_or_else(|| {
+            self.elements.push(None);
+            self.elements.len() - 1
+        })
+    }
+
+    /// Place index at top of the stack
+    fn rewire_top(&mut self, index: usize) {
+        let prev_top = self.top.replace(index);
+        if Some(index) == prev_top {
+            return;
+        }
+        let &El { below, above, .. } = self.elements[index].as_ref().unwrap();
+        self.link(below, above);
+        self.link(prev_top, Some(index));
+    }
+
+    /// Link two elements together by setting `above` and `below` indices
+    fn link(&mut self, below: Option<usize>, above: Option<usize>) {
+        if let Some(below) = below {
+            self.elements[below].as_mut().unwrap().above = above;
+        }
+        if let Some(above) = above {
+            self.elements[above].as_mut().unwrap().below = below;
+        }
+    }
+}
+
+impl<T: Eq + Hash + Clone> FromIterator<T> for UniqueStack<T> {
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        let mut stack = UniqueStack::new();
+        for item in iter {
+            stack.push(item);
+        }
+        stack
+    }
+}
+
+impl<T: Eq + Hash + Clone> Extend<T> for UniqueStack<T> {
+    fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
+        for item in iter {
+            self.push(item);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_push_and_pop() {
+        let mut stack = UniqueStack::new();
+        assert!(stack.push(1));
+        assert!(stack.push(2));
+        assert!(stack.push(3));
+        assert_eq!(stack.pop(), Some(3));
+        assert_eq!(stack.pop(), Some(2));
+        assert_eq!(stack.pop(), Some(1));
+        assert_eq!(stack.pop(), None);
+    }
+
+    #[test]
+    fn test_push_existing() {
+        let mut stack = UniqueStack::new();
+        assert!(stack.push(1));
+        assert!(stack.push(2));
+        assert!(!stack.push(1)); // Should return false for existing element
+        assert_eq!(stack.pop(), Some(1)); // 1 should now be on top
+        assert_eq!(stack.pop(), Some(2));
+        assert_eq!(stack.pop(), None);
+    }
+
+    #[test]
+    fn test_top() {
+        let mut stack = UniqueStack::new();
+        assert_eq!(stack.top(), None);
+        stack.push(1);
+        assert_eq!(stack.top(), Some(&1));
+        stack.push(2);
+        assert_eq!(stack.top(), Some(&2));
+    }
+
+    use rstest::rstest;
+
+    #[rstest]
+    #[case(vec![1, 2, 3, 2, 1], vec![1, 2, 3])]
+    #[case(vec![0, 0], vec![0])]
+    fn test_from_iter(#[case] input: Vec<i32>, #[case] expected: Vec<i32>) {
+        let mut stack: UniqueStack<i32> = input.into_iter().collect();
+
+        for &expected_value in expected.iter() {
+            assert_eq!(stack.pop(), Some(expected_value));
+        }
+        assert_eq!(stack.pop(), None);
+    }
+
+    #[test]
+    fn test_extend() {
+        let mut stack = UniqueStack::new();
+        stack.push(1);
+        stack.extend(vec![2, 3, 1, 4]);
+        assert_eq!(stack.pop(), Some(4));
+        assert_eq!(stack.pop(), Some(1));
+        assert_eq!(stack.pop(), Some(3));
+        assert_eq!(stack.pop(), Some(2));
+        assert_eq!(stack.pop(), None);
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "proptest")]
+mod proptests {
+    use std::iter;
+
+    use itertools::Itertools;
+    use proptest::prelude::*;
+
+    use super::*;
+    use crate::HashSet;
+
+    proptest! {
+        #[test]
+        fn proptest_unique_stack(input in prop::collection::vec(0..6usize, 0..50)) {
+            let mut stack: UniqueStack<usize> = input.iter().cloned().collect();
+
+            // Create the expected result by traversing the input vector from back to front
+            let mut expected = Vec::new();
+            let mut seen = HashSet::default();
+            for &item in input.iter().rev() {
+                if seen.insert(item) {
+                    expected.push(item);
+                }
+            }
+
+            // Drain the stack and compare with expected result
+            let actual = iter::from_fn(|| stack.pop()).collect_vec();
+
+            assert_eq!(actual, expected, "Stack contents do not match expected unique elements");
+        }
+    }
+}

--- a/src/utils/unique_stack.rs
+++ b/src/utils/unique_stack.rs
@@ -15,7 +15,7 @@ struct El<T> {
 ///
 /// A first in first out stack. If pushing an element that is already
 /// in the stack, the operation moves that element to the top of the stack.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) struct UniqueStack<T> {
     elements: Vec<Option<El<T>>>,
     indices: HashMap<T, usize>,


### PR DESCRIPTION
This replaces `bind_with_scheme` on `IndexMap`s. The API makes more sense this way, and the new functionality is slightly upgraded compared to before.

This is a relatively minor PR that stacks on #53. Will rebase onto that once merged to `main`.
